### PR TITLE
Allow custom X startup file

### DIFF
--- a/doc/01_Manual.txt
+++ b/doc/01_Manual.txt
@@ -75,6 +75,10 @@ The first session ever started became the default session.
 There may some option or command variant available which is not documented. They
 are there to be more comfortable or due to the laziness of the coder.
 
+With version v0.6 of tbsm it was decided that tbsm will never have an internal
+variable starting with 'own'. So you are always save to use 'ownFoo' in your
+custom session startup script. See 4-5- as an example.
+
 
 3- Post Install Tasks
 =======================
@@ -115,6 +119,8 @@ instead of the noted build in command. Here the simplest possible an example:
   # do something before
   startx ${bin[@]} -- ${XserverArg[@]}
   # do something after
+
+For a little more complex example see 4-5-
 
 
 4- Tips & Tricks
@@ -165,6 +171,23 @@ Thanks to toke, https://github.com/loh-tar/tbsm/pull/12
   [[ -n "$XDG_VTNR" && $XDG_VTNR -le 2 ]] && tbsm
 
 Thanks to 0BAD-C0DE, https://aur.archlinux.org/packages/tbsm#comment-841043
+
+
+4-5- Redirect Xorg output into custom logfile
+-----------------------------------------------
+With this redirection will the terminal not fluted with unreadable chatter from
+the X server or the session. Interesting read! Of cause you can also dump it by
+redirect to /dev/null
+
+  $ cat ~/.config/tbsm/start-x
+  # tbsm will never have a variable starting with 'own'
+  ownLogfile="/tmp/$USER/tbsm/xorg-chatter.log"
+  mkdir -p $(dirname $ownLogfile)
+  # 'info' is one of tbsm's own functions
+  info "Xorg messages will directed to: $ownLogfile" 2 # 2=loglevel, try 1
+  # We also set an option to improve readability on high resolution displays in
+  # a slightly strange way. Typical we would set XserverArg in the conf file
+  startx ${bin[@]} -- ${XserverArg[@]} -dpi 120 2> ${ownLogfile}
 
 
 5- Contact

--- a/doc/01_Manual.txt
+++ b/doc/01_Manual.txt
@@ -101,6 +101,22 @@ familiar with it. But quickly you will be annoyed and therefore have all themes
 a setting verboseLevel="2" (--info) which should be good for most cases.
 
 
+3-2- Special Start X Configuration
+------------------------------------
+By default will X started this way:
+
+  startx ${bin[@]} -- ${XserverArg[@]}
+
+If that doesn't full fill your needs, you can create an own startup file in one
+of the config directories. It must be named "start-x" and will be "sourced"
+instead of the noted build in command. Here the simplest possible an example:
+
+  $ cat ~/.config/tbsm/start-x
+  # do something before
+  startx ${bin[@]} -- ${XserverArg[@]}
+  # do something after
+
+
 4- Tips & Tricks
 ==================
 Here are some hints collected in order as they was reported. Should that list

--- a/doc/01_Manual.txt
+++ b/doc/01_Manual.txt
@@ -75,10 +75,6 @@ The first session ever started became the default session.
 There may some option or command variant available which is not documented. They
 are there to be more comfortable or due to the laziness of the coder.
 
-With version v0.6 of tbsm it was decided that tbsm will never have an internal
-variable starting with 'own'. So you are always save to use 'ownFoo' in your
-custom session startup script. See 4-5- as an example.
-
 
 3- Post Install Tasks
 =======================
@@ -112,12 +108,15 @@ By default will X started this way:
   startx ${bin[@]} -- ${XserverArg[@]}
 
 If that doesn't full fill your needs, you can create an own startup file in one
-of the config directories. It must be named "start-x" and will be "sourced"
-instead of the noted build in command. Here the simplest possible an example:
+of the config directories. It must be named "start-x" and will be called with
+the three shown arguments, but quoted. As the file is called, it must be
+executable. Here the simplest possible example:
 
   $ cat ~/.config/tbsm/start-x
+  #!/bin/bash
+  # $@ contains: $1="${bin[@]}"  $2="--"  $3="${XserverArg[@]}"
   # do something before
-  startx ${bin[@]} -- ${XserverArg[@]}
+  startx $@
   # do something after
 
 For a little more complex example see 4-5-
@@ -180,14 +179,13 @@ the X server or the session. Interesting read! Of cause you can also dump it by
 redirect to /dev/null
 
   $ cat ~/.config/tbsm/start-x
-  # tbsm will never have a variable starting with 'own'
+  #!/bin/bash
   ownLogfile="/tmp/$USER/tbsm/xorg-chatter.log"
   mkdir -p $(dirname $ownLogfile)
-  # 'info' is one of tbsm's own functions
-  info "Xorg messages will directed to: $ownLogfile" 2 # 2=loglevel, try 1
   # We also set an option to improve readability on high resolution displays in
   # a slightly strange way. Typical we would set XserverArg in the conf file
-  startx ${bin[@]} -- ${XserverArg[@]} -dpi 120 2> ${ownLogfile}
+  # Just remember: $@ is like "${bin[@]} -- ${XserverArg[@]}"
+  startx $@ -dpi 120 2> ${ownLogfile}
 
 
 5- Contact

--- a/src/tbsm
+++ b/src/tbsm
@@ -35,12 +35,6 @@
 # TODO
 #   Consider http://wiki.bash-hackers.org/howto/collapsing_functions
 
-# NOTE NEVER EVER CREATE A VARIABLE STARTING WITH 'own' !!!
-#      Since v0.6 we support custom session startup scripts. We like to give the
-#      user some 'name-space' where he is save not to accidentally overwrite
-#      some tbsm internal variable. 'my' may a better choice, but glaringly is that
-#      option already taken.
-
 declare -r myName="tbsm"
 declare -r myLongName="Terminal Based Session Manager"
 declare -r myVersion="0.5" # Dez 2018
@@ -512,12 +506,16 @@ runXSession() {
   local -a searchPath=("${configDir}" "${sessionStartDirs[@]}")
   for path in ${searchPath[@]}; do
     local startFile="${path}/start-x"
-    if [[ -f "${startFile}" ]]; then
+    if [[ -x "${startFile}" ]]; then
       info "Start X by ${startFile}"
-      source "${startFile}"
+      "${startFile}" "${bin[@]}" "--" "${XserverArg[@]}"
       return
     fi
-    info "No ${startFile}"
+    if [[ -f "${startFile}" ]]; then
+      warn "Not executable ${startFile}"
+    else
+      info "No ${startFile}"
+    fi
   done
 
   # No special start file found, use the build in

--- a/src/tbsm
+++ b/src/tbsm
@@ -41,14 +41,16 @@ declare -r myVersion="0.5" # Dez 2018
 declare -r myDescription="A pure bash session and application launcher"
 
 # Let's support XDG Base Directory Specification
-# Line up the config dirs in reverse order
-declare -a systemConfigDirs
+declare -a systemConfigDirs # Line up in reverse order to apply config files
+declare -a sessionStartDirs # Line up in normal order to find first configured file
 oldIFS="$IFS"; IFS=":"
 for DIR in ${XDG_CONFIG_DIRS:-/etc/xdg} ; do
   systemConfigDirs=("${DIR}/${myName}" "${systemConfigDirs[@]}")
+  sessionStartDirs=("${sessionStartDirs[@]}" "${DIR}/${myName}")
 done
 IFS="$oldIFS"
 declare -r systemConfigDirs=( "${systemConfigDirs[@]}" )
+declare -r sessionStartDirs=( "${sessionStartDirs[@]}" )
 declare -r configDir="${XDG_CONFIG_HOME:-${HOME}/.config}/${myName}"
 
 declare -r installPfad=""
@@ -214,6 +216,7 @@ readConfigFile() {
   # at the same time some verbose level. That why we collect data and print later
   for path in ${searchPath[@]}; do
     local fullPath="${path}/${cfgFile}"
+    echo "Check: ${fullPath}"
     if [[ ! -r "${fullPath}" ]]; then
       failPath=("${failPath[@]}" "${fullPath}")
       continue;
@@ -459,8 +462,7 @@ runSession() {
       ;;
     S)  # X Sessions
       if [[ $runInTTY ]]; then
-        info "Run command: startx ${bin[@]} -- ${XserverArg[@]}"
-        startx ${bin[@]} -- ${XserverArg[@]}
+        runXSession "${bin[@]}"
       else
         info "Not running in tty. Will not start X session." "0"
         return 1
@@ -479,8 +481,7 @@ runSession() {
       ;;
     X)  # Applications
       if [[ $runInTTY ]]; then
-        info "Run command: startx ${bin[@]} -- ${XserverArg[@]}"
-        startx ${bin[@]} -- ${XserverArg[@]}
+        runXSession "${bin[@]}"
       else
         info "Not running in tty, run: ${bin[@]}"
         ${bin[@]}
@@ -499,6 +500,24 @@ runSession() {
     then pushCommand ${command}
     else pushCommand "menu"
   fi
+}
+
+runXSession() {
+  # Has the user configured some custom start X file?
+  local -a searchPath=("${configDir}" "${sessionStartDirs[@]}")
+  for path in ${searchPath[@]}; do
+    local startFile="${path}/start-x"
+    if [[ -f "${startFile}" ]]; then
+      info "Start X by ${startFile}"
+      source "${startFile}"
+      return
+    fi
+    info "No ${startFile}"
+  done
+
+  # No special start file found, use the build in
+  info "Run command: startx ${bin[@]} -- ${XserverArg[@]}"
+  startx ${bin[@]} -- ${XserverArg[@]}
 }
 
 showQuickMenu() {

--- a/src/tbsm
+++ b/src/tbsm
@@ -216,7 +216,6 @@ readConfigFile() {
   # at the same time some verbose level. That why we collect data and print later
   for path in ${searchPath[@]}; do
     local fullPath="${path}/${cfgFile}"
-    echo "Check: ${fullPath}"
     if [[ ! -r "${fullPath}" ]]; then
       failPath=("${failPath[@]}" "${fullPath}")
       continue;

--- a/src/tbsm
+++ b/src/tbsm
@@ -35,6 +35,12 @@
 # TODO
 #   Consider http://wiki.bash-hackers.org/howto/collapsing_functions
 
+# NOTE NEVER EVER CREATE A VARIABLE STARTING WITH 'own' !!!
+#      Since v0.6 we support custom session startup scripts. We like to give the
+#      user some 'name-space' where he is save not to accidentally overwrite
+#      some tbsm internal variable. 'my' may a better choice, but glaringly is that
+#      option already taken.
+
 declare -r myName="tbsm"
 declare -r myLongName="Terminal Based Session Manager"
 declare -r myVersion="0.5" # Dez 2018


### PR DESCRIPTION
Some user missed that typical X startup files like .xinit or .Xresources
are not taken into account. Now can such users create their own startup
file in the system or user config directory and can do there what ever
seems appropriate.

The name must be "start-x" and it will be "sourced".
See Manual.txt for details.

Close #14